### PR TITLE
include <iostream> was required for std::cout call

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -7,6 +7,7 @@
 
 
 #include <helpers.h>
+#include <iostream>
 
   void hexdump(const void *ptr, int buflen) {
       unsigned char *buf = (unsigned char*)ptr;


### PR DESCRIPTION
http://www.cplusplus.com/reference/iostream/cout/

I needed to include iostream in order to get the compile to work.
